### PR TITLE
修正箇所の変更を適用

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -18,7 +18,8 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Article < ApplicationRecord
-  belongs_to :user
+  validates :title, presence: true
+  belongs_to :user, optional: true
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy
 end

--- a/app/models/article_like.rb
+++ b/app/models/article_like.rb
@@ -19,6 +19,6 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class ArticleLike < ApplicationRecord
-  belongs_to :user
-  belongs_to :article
+  belongs_to :user, optional: true
+  belongs_to :article, optional: true
 end

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -20,6 +20,7 @@
 #  fk_rails_...  (user_id => users.id)
 #
 class Comment < ApplicationRecord
-  belongs_to :user
-  belongs_to :article
+  validates :body, presence: true
+  belongs_to :user, optional: true
+  belongs_to :article, optional: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -32,6 +32,7 @@
 #
 class User < ApplicationRecord
   extend Devise::Models
+  validates :name, presence: true
   has_many :articles, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :article_likes, dependent: :destroy

--- a/spec/factories/article_likes.rb
+++ b/spec/factories/article_likes.rb
@@ -20,7 +20,5 @@
 #
 FactoryBot.define do
   factory :article_like do
-    user { nil }
-    article { nil }
   end
 end

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -19,7 +19,6 @@
 #
 FactoryBot.define do
   factory :article do
-    title { "MyString" }
-    body { "MyText" }
+    title { Faker::Hacker.abbreviation }
   end
 end

--- a/spec/factories/comments.rb
+++ b/spec/factories/comments.rb
@@ -21,8 +21,6 @@
 #
 FactoryBot.define do
   factory :comment do
-    body { "MyText" }
-    user { nil }
-    article { nil }
+    body { Faker::Hacker.say_something_smart }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :user do
+    name { Faker::Name.name }
+    email { Faker::Internet.email }
+    password { Faker::Internet.password }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
-    name { Faker::Name.name }
-    email { Faker::Internet.email }
-    password { Faker::Internet.password }
+    name { Faker::Lorem.characters(number: Random.new.rand(1..30)) }
+    sequence(:email) {|n| "#{n}_#{Faker::Internet.email}" }
+    password { Faker::Internet.password(min_length: 8, max_length: 32, mix_case: true, special_characters: true) }
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -20,5 +20,20 @@
 require "rails_helper"
 
 RSpec.describe Article, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "記事のタイトルが指定しているとき" do
+    let(:user) { create(:user) }
+    let(:article) { build(:article) }
+
+    it "記事が作られる" do
+      expect(article).to be_valid
+    end
+  end
+
+  context "タイトルを入力していないとき" do
+    let(:article) { build(:article, title: nil) }
+
+    it "記事作成に失敗する" do
+      expect(article).not_to be_valid
+    end
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -22,5 +22,21 @@
 require "rails_helper"
 
 RSpec.describe Comment, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  context "コメントの本文が記述されているとき" do
+    let(:user) { create(:user) }
+    let(:article) { create(:article) }
+    let(:comment) { build(:comment) }
+
+    it "コメントが作られる" do
+      expect(comment).to be_valid
+    end
+  end
+
+  context "本文を入力していないとき" do
+    let(:comment) { build(:comment, body: nil) }
+
+    it "コメント作成に失敗する" do
+      expect(comment).not_to be_valid
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  context "name を指定しているとき" do
+    it "ユーザーが作られる" do
+      user = build(:user)
+      expect(user).to be_valid
+    end
+  end
+
+  context "name を指定していないとき" do
+    it "ユーザー作成に失敗する" do
+      user = build(:user, name: nil)
+      expect(user).to be_invalid
+      expect(user.errors.details[:name][0][:error]).to eq :blank
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,18 +1,43 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe User, type: :model do
   context "name を指定しているとき" do
+    let(:user) { build(:user) }
+
     it "ユーザーが作られる" do
-      user = build(:user)
       expect(user).to be_valid
     end
   end
 
-  context "name を指定していないとき" do
+  context "名前を入力していないとき" do
+    let(:user) { build(:user, name: nil) }
+
     it "ユーザー作成に失敗する" do
-      user = build(:user, name: nil)
-      expect(user).to be_invalid
-      expect(user.errors.details[:name][0][:error]).to eq :blank
+      expect(user).not_to be_valid
+    end
+  end
+
+  context "名前のみ入力している場合" do
+    let(:user) { build(:user, email: nil, password: nil) }
+
+    it "エラーが発生する" do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context "email がない場合" do
+    let(:user) { build(:user, email: nil) }
+
+    it "エラーが発生する" do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context "password がない場合" do
+    let(:user) { build(:user, password: nil) }
+
+    it "エラーが発生する" do
+      expect(user).not_to be_valid
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,10 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  config.define_derived_metadata do |meta|
+    meta[:aggregate_failures] = true unless meta.has_key?(:aggregate_failures)
+  end
+
   # The settings below are suggested to provide a good initial experience
   # with RSpec, but feel free to customize to your heart's content.
   #   # This allows you to limit a spec run to individual examples or groups


### PR DESCRIPTION
## 概要
- revert commit を修正

## 補足
 - コミットメッセージを修正しようと、SorceTreeの「コミット適用前に戻す」を実行してしまったことで変更が適用されていなかったファイルを修正。