### PR TITLE
記事詳細機能の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -4,5 +4,10 @@ module Api::V1
       articles = Article.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
     end
+
+    def show
+      article = Article.find(params[:id])
+      render json: article, each_serializer: Api::V1::ArticleSerializer
+    end
   end
 end

--- a/app/serializers/api/v1/article_serializer.rb
+++ b/app/serializers/api/v1/article_serializer.rb
@@ -1,0 +1,4 @@
+class Api::V1::ArticleSerializer < ActiveModel::Serializer
+  attributes :id, :title, :body, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
+end

--- a/spec/articles_spec.rb
+++ b/spec/articles_spec.rb
@@ -15,4 +15,28 @@ RSpec.describe "Api::V1::Articles", type: :request do
       expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
     end
   end
+
+  describe "GET /api/v1/articles/:id" do
+    subject { get(api_v1_article_path(article_id)) }
+
+    context "指定した idの記事 が存在するとき" do
+      let(:article_id) { article.id }
+      let(:article) { create(:article) }
+
+      it "その記事のレコードが取得できる" do
+        subject
+
+        res = JSON.parse(response.body)
+        expect(res["id"]).to eq article.id
+      end
+    end
+
+    context "指定した idの記事 が存在しないとき" do
+      let(:article_id) { 77777 }
+
+      it "その記事が見つからない" do
+        expect { subject }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
 - タイトルの通り

## 補足
 - ActiveModelSerializers を使って、記事の詳細を json で返す機能を実装
 - request spec を実装

## レビューポイント
 - 誰でも見れるようにする
 - 日付はフロントで表示する際に、更新日をもとに表示する