### PR TITLE
記事作成の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,7 @@ group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem "factory_bot_rails"
   gem "faker"
+  gem "pry-byebug"
   gem "pry-doc"
   gem "pry-rails"
   gem "rspec-rails", "~> 5.0.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,9 @@ GEM
     pry (0.14.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.8.0)
+      byebug (~> 11.0)
+      pry (~> 0.10)
     pry-doc (1.3.0)
       pry (~> 0.11)
       yard (~> 0.9.11)
@@ -271,6 +274,7 @@ DEPENDENCIES
   faker
   listen (~> 3.2)
   pg (>= 0.18, < 2.0)
+  pry-byebug
   pry-doc
   pry-rails
   puma (~> 4.1)

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -9,5 +9,16 @@ module Api::V1
       article = Article.find(params[:id])
       render json: article, each_serializer: Api::V1::ArticleSerializer
     end
+
+    def create
+      article = current_user.articles.create!(article_params)
+      render json: article, each_serializer: Api::V1::ArticleSerializer
+    end
+
+    private
+
+      def article_params
+        params.require(:article).permit(:title, :body)
+      end
   end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,2 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
+  def current_user
+    @current_user ||= User.first
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
 class ApplicationController < ActionController::Base
   include DeviseTokenAuth::Concerns::SetUserByToken
+  protect_from_forgery with: :null_session
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,7 @@ module WonderfulEditor
     end
 
     config.api_only = true
+    config.middleware.use ActionDispatch::Flash
 
     # Don't generate system test files.
     config.generators.system_tests = nil


### PR DESCRIPTION
## 概要
 - タイトルの通り

## 補足
 - ダミーの _**current_user**_ メソッドを定義
   - base_api_controller に定義して、仮実装として「users テーブルの一番初めのユーザー」を引用するように実装
 - 新規作成する記事の user_id が current_user の id になる API を実装
 - テストにスタブを定義
   - テストで `allow_any_instance_of `メソッドを使用して _**current_user**_ を呼び出せるように実装