### PR TITLE
記事更新の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -7,12 +7,18 @@ module Api::V1
 
     def show
       article = Article.find(params[:id])
-      render json: article, each_serializer: Api::V1::ArticleSerializer
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
 
     def create
       article = current_user.articles.create!(article_params)
-      render json: article, each_serializer: Api::V1::ArticleSerializer
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
+    def update
+      article = current_user.articles.find(params[:id])
+      article.update!(article_params)
+      render json: article, serializer: Api::V1::ArticleSerializer
     end
 
     private

--- a/config/rubocop/rspec.yml
+++ b/config/rubocop/rspec.yml
@@ -38,6 +38,9 @@ RSpec/ImplicitExpect:
 RSpec/InstanceVariable:
   Enabled: false
 
+RSpec/LetSetup:
+  Enabled: false
+
 # 変に名前つけて呼ぶ方が分かりづらい。
 # テスト対象メソッドを呼ぶだけの subject 以外を書かないようにする方が効く。
 RSpec/NamedSubject:

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,4 +93,5 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   Kernel.srand config.seed
+  RSpec::Matchers.define_negated_matcher :not_change, :change
 end


### PR DESCRIPTION
## 概要
 - タイトルの通り

## 補足
 - articles_controller.rb, articles_spec.rb にメインとなる実装を追加
 - articles_controller.rb を微修正
 - rspec.yml に rubocop の設定を追加
 - spec_helper.rb にカスタムマッチャを書けるようになる設定を追加