### PR TITLE
記事削除の実装

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -21,6 +21,12 @@ module Api::V1
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
+    def destroy
+      article = current_user.articles.find(params[:id])
+      article.destroy!
+      render json: article, serializer: Api::V1::ArticleSerializer
+    end
+
     private
 
       def article_params


### PR DESCRIPTION
## 概要
 - タイトルの通り

## 補足
 - articles_controller.rb に destroyアクションを追加
 - articles_spec.rb に DELETE のテストを追加

## レビューポイント
 - 削除の実装をに関しては、「削除が実行されたら数字がどうなるのか？」を考えることが重要
   - `expect(response).to have_http_status(:no_content)`
   - `& change { Article.count }.by(0)`