### PR TITLE
新規登録 API のテストの実装

### DIFF
--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,12 +1,11 @@
 class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
-
   private
 
-  def sign_up_params
-    params.permit(:name, :email, :password, :password_confirmation)
-  end
+    def sign_up_params
+      params.permit(:name, :email, :password, :password_confirmation)
+    end
 
-  def account_update_params
-    params.permit(:name, :email)
-  end
+    def account_update_params
+      params.permit(:name, :email)
+    end
 end

--- a/app/controllers/api/v1/auth/registrations_controller.rb
+++ b/app/controllers/api/v1/auth/registrations_controller.rb
@@ -1,0 +1,12 @@
+class Api::V1::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
+
+  private
+
+  def sign_up_params
+    params.permit(:name, :email, :password, :password_confirmation)
+  end
+
+  def account_update_params
+    params.permit(:name, :email)
+  end
+end

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -5,11 +5,11 @@ DeviseTokenAuth.setup do |config|
   # client is responsible for keeping track of the changing tokens. Change
   # this to false to prevent the Authorization header from changing after
   # each request.
-  # config.change_headers_on_each_request = true
+  config.change_headers_on_each_request = false
 
   # By default, users will need to re-authenticate after 2 weeks. This setting
   # determines how long tokens will remain valid after they are issued.
-  # config.token_lifespan = 2.weeks
+  config.token_lifespan = 2.weeks
 
   # Limiting the token_cost to just 4 in testing will increase the performance of
   # your test suite dramatically. The possible cost value is within range from 4
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  # config.headers_names = {:'access-token' => 'access-token',
-  #                        :'client' => 'client',
-  #                        :'expiry' => 'expiry',
-  #                        :'uid' => 'uid',
-  #                        :'token-type' => 'token-type' }
+  config.headers_names = {:'access-token' => 'access-token',
+                         :'client' => 'client',
+                         :'expiry' => 'expiry',
+                         :'uid' => 'uid',
+                         :'token-type' => 'token-type' }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/initializers/devise_token_auth.rb
+++ b/config/initializers/devise_token_auth.rb
@@ -42,11 +42,11 @@ DeviseTokenAuth.setup do |config|
   # config.default_callbacks = true
 
   # Makes it possible to change the headers names
-  config.headers_names = {:'access-token' => 'access-token',
-                         :'client' => 'client',
-                         :'expiry' => 'expiry',
-                         :'uid' => 'uid',
-                         :'token-type' => 'token-type' }
+  config.headers_names = { 'access-token': "access-token",
+                            client: "client",
+                            expiry: "expiry",
+                            uid: "uid",
+                            'token-type': "token-type" }
 
   # By default, only Bearer Token authentication is implemented out of the box.
   # If, however, you wish to integrate with legacy Devise authentication, you can

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,8 +4,8 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {
-        registrations: 'api/v1/auth/registrations'
-    }
+        registrations: "api/v1/auth/registrations",
+      }
       resources :articles
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,9 @@ Rails.application.routes.draw do
 
   namespace :api do
     namespace :v1 do
-      mount_devise_token_auth_for "User", at: "auth"
+      mount_devise_token_auth_for "User", at: "auth", controllers: {
+        registrations: 'api/v1/auth/registrations'
+    }
       resources :articles
     end
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -32,6 +32,7 @@ FactoryBot.define do
   factory :user do
     name { Faker::Lorem.characters(number: Random.new.rand(1..30)) }
     sequence(:email) {|n| "#{n}_#{Faker::Internet.email}" }
-    password { Faker::Internet.password(min_length: 8, max_length: 32, mix_case: true, special_characters: true) }
+    password { "abc1234" }
+    password_confirmation { "abc1234" }
   end
 end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,0 +1,7 @@
+require 'rails_helper'
+
+RSpec.describe "Api::V1::Auth::Registrations", type: :request do
+  describe "GET /index" do
+    pending "add some examples (or delete) #{__FILE__}"
+  end
+end

--- a/spec/requests/api/v1/auth/registrations_spec.rb
+++ b/spec/requests/api/v1/auth/registrations_spec.rb
@@ -1,7 +1,72 @@
-require 'rails_helper'
+require "rails_helper"
 
 RSpec.describe "Api::V1::Auth::Registrations", type: :request do
-  describe "GET /index" do
-    pending "add some examples (or delete) #{__FILE__}"
+  describe "POST /api/v1/auth" do
+    subject { post(api_v1_user_registration_path, params: params) }
+
+    context "新規登録が上手くいく場合" do
+      let(:params) { attributes_for(:user) }
+
+      # rubocop:disable RSpec/MultipleExpectations
+      it "正しい情報を入力すればユーザーは新規登録ができる" do
+        # rubocop:enable RSpec/MultipleExpectations
+        expect { subject }.to change { User.count }.by(1)
+        expect(response).to have_http_status(:ok)
+        res = JSON.parse(response.body)
+        expect(res["data"]["name"]).to eq params[:name]
+        expect(res["data"]["email"]).to eq(User.last.email)
+      end
+
+      # rubocop:disable RSpec/MultipleExpectations
+      it "header 情報を取得することができる" do
+        # rubocop:enable RSpec/MultipleExpectations
+        subject
+        header = response.header
+        expect(header["access-token"]).to be_present
+        expect(header["client"]).to be_present
+        expect(header["expiry"]).to be_present
+        expect(header["uid"]).to be_present
+        expect(header["token-type"]).to be_present
+      end
+    end
+
+    context "name が存在しないとき" do
+      let(:params) { attributes_for(:user, name: nil) }
+
+      # rubocop:disable RSpec/MultipleExpectations
+      it "エラーする" do
+        # rubocop:enable RSpec/MultipleExpectations
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(res["errors"]["name"]).to include "can't be blank"
+      end
+    end
+
+    context "email が存在しないとき" do
+      let(:params) { attributes_for(:user, email: nil) }
+
+      # rubocop:disable RSpec/MultipleExpectations
+      it "エラーする" do
+        # rubocop:enable RSpec/MultipleExpectations
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(res["errors"]["email"]).to include "can't be blank"
+      end
+    end
+
+    context "password が存在しないとき" do
+      let(:params) { attributes_for(:user, password: nil) }
+
+      # rubocop:disable RSpec/MultipleExpectations
+      it "エラーする" do
+        # rubocop:enable RSpec/MultipleExpectations
+        expect { subject }.to change { User.count }.by(0)
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:unprocessable_entity)
+        expect(res["errors"]["password"]).to include "can't be blank"
+      end
+    end
   end
 end


### PR DESCRIPTION
## 概要
 - タイトルの通り

## 補足
 - 新規登録の API のテスト を 正常系、異常系ともに記述
 - ヘッダー情報が取得できることを確認

## レビューポイント
 - rubocop に指摘された箇所を複数行修正
 - FactoryBot の password, password_confirmation の設定をどちらも同じ設定で、別のパターンに変更