### PR TITLE
既存 API の修正

### DIFF
--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,10 +1,5 @@
 module Api::V1
   class ArticlesController < BaseApiController
-    # before_action :authenticate_api_v1_user!, only: [:create, :update, :destroy]
-    before_action :authenticate_user!, except: [:index, :show]
-    alias_method :devise_current_user, :current_user
-    # before_action :authenticate_api_v1_user!
-    # before_action :authenticate_user!
 
     def index
       articles = Article.order(updated_at: :desc)
@@ -35,25 +30,10 @@ module Api::V1
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
-    def current_user
-      user = User.create!(user_params)
-      articles = current_user.articles
-      #logic to get a handle on current user goes here
-    end
-
-    # alias_method current_user create
-    # alias authenticate_user! authenticate_api_v1_user!
-    # alias_method authenticate_user! authenticate_api_v1_user!
-    # alias mse metroway
-
     private
 
       def article_params
         params.require(:article).permit(:title, :body)
-      end
-
-      def user_params
-        params.require(:user).permit(:name, :email, :password)
       end
   end
 end

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,7 @@
 module Api::V1
   class ArticlesController < BaseApiController
+    before_action :authenticate_api_v1_user!
+
     def index
       articles = Article.order(updated_at: :desc)
       render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
@@ -11,7 +13,9 @@ module Api::V1
     end
 
     def create
-      article = current_user.articles.create!(article_params)
+      binding.pry
+      article = current_api_v1_user.articles.create!(article_params)
+      binding.pry
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,5 +1,6 @@
 module Api::V1
   class ArticlesController < BaseApiController
+    before_action :authenticate_user!, only: [:create, :update, :destroy]
 
     def index
       articles = Article.order(updated_at: :desc)
@@ -12,9 +13,10 @@ module Api::V1
     end
 
     def create
-      binding.pry
-      article = current_api_v1_user.articles.create!(article_params)
-      binding.pry
+      # binding.pry
+      article = current_user.articles.create!(article_params)
+      # article = current_api_v1_user.articles.create!(article_params)
+      # binding.pry
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 

--- a/app/controllers/api/v1/articles_controller.rb
+++ b/app/controllers/api/v1/articles_controller.rb
@@ -1,6 +1,10 @@
 module Api::V1
   class ArticlesController < BaseApiController
-    before_action :authenticate_api_v1_user!
+    # before_action :authenticate_api_v1_user!, only: [:create, :update, :destroy]
+    before_action :authenticate_user!, except: [:index, :show]
+    alias_method :devise_current_user, :current_user
+    # before_action :authenticate_api_v1_user!
+    # before_action :authenticate_user!
 
     def index
       articles = Article.order(updated_at: :desc)
@@ -31,10 +35,25 @@ module Api::V1
       render json: article, serializer: Api::V1::ArticleSerializer
     end
 
+    def current_user
+      user = User.create!(user_params)
+      articles = current_user.articles
+      #logic to get a handle on current user goes here
+    end
+
+    # alias_method current_user create
+    # alias authenticate_user! authenticate_api_v1_user!
+    # alias_method authenticate_user! authenticate_api_v1_user!
+    # alias mse metroway
+
     private
 
       def article_params
         params.require(:article).permit(:title, :body)
+      end
+
+      def user_params
+        params.require(:user).permit(:name, :email, :password)
       end
   end
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,38 +1,5 @@
 class Api::V1::BaseApiController < ApplicationController
-  include DeviseTokenAuth::Concerns::SetUserByToken
-  before_action :authenticate_user!, except: [:index, :show]
-  alias :authenticate_user! :authenticate_api_v1_user!
-
-  def current_api_v1_user
-  article = current_api_v1_user.articles
-  end
-
-  Api::V1::BaseApiController.new.create
   alias_method :current_user, :current_api_v1_user
-
-  def create
-    article = current_api_v1_user.articles.create!(article_params)
-    render json: article, serializer: Api::V1::ArticleSerializer
-  end
-
-  Api::V1::BaseApiController.new.create
-  alias_method :current_create, :create
-
-  def update
-    article = current_api_v1_user.articles.find(params[:id])
-    article.update!(article_params)
-    render json: article, serializer: Api::V1::ArticleSerializer
-  end
-
-  Api::V1::BaseApiController.new.update
-  alias_method :current_update, :update
-
-  def destroy
-    article = current_api_v1_user.articles.find(params[:id])
-    article.destroy!
-    render json: article, serializer: Api::V1::ArticleSerializer
-  end
-
-  Api::V1::BaseApiController.new.destroy
-  alias_method :current_destroy, :destroy
+  alias_method :authenticate_user!, :authenticate_api_v1_user!
+  alias_method :user_signed_in?, :api_v1_user_signed_in?
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,8 +1,38 @@
 class Api::V1::BaseApiController < ApplicationController
-  # skip_before_action :authenticate_api_v1_user! , only: %i[ index show ]
   include DeviseTokenAuth::Concerns::SetUserByToken
-  # before_action :authenticate_api_v1_user!
+  before_action :authenticate_user!, except: [:index, :show]
+  alias :authenticate_user! :authenticate_api_v1_user!
 
-  # articles = current_user.articles
+  def current_api_v1_user
+  article = current_api_v1_user.articles
+  end
 
+  Api::V1::BaseApiController.new.create
+  alias_method :current_user, :current_api_v1_user
+
+  def create
+    article = current_api_v1_user.articles.create!(article_params)
+    render json: article, serializer: Api::V1::ArticleSerializer
+  end
+
+  Api::V1::BaseApiController.new.create
+  alias_method :current_create, :create
+
+  def update
+    article = current_api_v1_user.articles.find(params[:id])
+    article.update!(article_params)
+    render json: article, serializer: Api::V1::ArticleSerializer
+  end
+
+  Api::V1::BaseApiController.new.update
+  alias_method :current_update, :update
+
+  def destroy
+    article = current_api_v1_user.articles.find(params[:id])
+    article.destroy!
+    render json: article, serializer: Api::V1::ArticleSerializer
+  end
+
+  Api::V1::BaseApiController.new.destroy
+  alias_method :current_destroy, :destroy
 end

--- a/app/controllers/api/v1/base_api_controller.rb
+++ b/app/controllers/api/v1/base_api_controller.rb
@@ -1,5 +1,8 @@
 class Api::V1::BaseApiController < ApplicationController
-  def current_user
-    @current_user ||= User.first
-  end
+  # skip_before_action :authenticate_api_v1_user! , only: %i[ index show ]
+  include DeviseTokenAuth::Concerns::SetUserByToken
+  # before_action :authenticate_api_v1_user!
+
+  # articles = current_user.articles
+
 end

--- a/spec/articles_spec.rb
+++ b/spec/articles_spec.rb
@@ -45,15 +45,16 @@ RSpec.describe "Api::V1::Articles", type: :request do
 
   describe "POST /api/v1/articles" do
     # subject { post(api_v1_articles_path, params: params, headers: headers) }
-    subject { post(api_v1_articles_path, params: params) }
+    subject { post(api_v1_articles_path, params: params, params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
 
     # rubocop:disable RSpec/MultipleExpectations
-    it "ユーザーのレコードが作成できる" do
+    fit "ユーザーのレコードが作成できる" do
       # rubocop:enable RSpec/MultipleExpectations
+      binding.pry
       expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
       res = JSON.parse(response.body)
       expect(res["title"]).to eq params[:article][:title]

--- a/spec/articles_spec.rb
+++ b/spec/articles_spec.rb
@@ -44,31 +44,32 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "POST /api/v1/articles" do
-    # subject { post(api_v1_articles_path, params: params, headers: headers) }
-    subject { post(api_v1_articles_path, params: params, params, headers: headers) }
+    subject { post(api_v1_articles_path, params: params, headers: headers) }
 
-    let(:params) { { article: attributes_for(:article) } }
-    let(:current_user) { create(:user) }
-    # before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    context "ログインユーザーが記事を作成するとき" do
+      let(:params) { { article: attributes_for(:article) } }
+      let(:current_user) { create(:user) }
+      let(:headers) { current_user.create_new_auth_token }
 
-    # rubocop:disable RSpec/MultipleExpectations
-    fit "ユーザーのレコードが作成できる" do
-      # rubocop:enable RSpec/MultipleExpectations
-      binding.pry
-      expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
-      res = JSON.parse(response.body)
-      expect(res["title"]).to eq params[:article][:title]
-      expect(res["body"]).to eq params[:article][:body]
-      expect(response).to have_http_status(:ok)
+      # rubocop:disable RSpec/MultipleExpectations
+      it "ユーザーのレコードが作成できる" do
+        # rubocop:enable RSpec/MultipleExpectations
+
+        expect { subject }.to change { Article.where(user_id: current_user.id).count }.by(1)
+        res = JSON.parse(response.body)
+        expect(res["title"]).to eq params[:article][:title]
+        expect(res["body"]).to eq params[:article][:body]
+        expect(response).to have_http_status(:ok)
+      end
     end
   end
 
   describe "PATCH /api/v1/articles/:id" do
-    subject { patch(api_v1_article_path(article.id), params: params) }
+    subject { patch(api_v1_article_path(article.id), params: params, headers: headers) }
 
     let(:params) { { article: attributes_for(:article) } }
     let(:current_user) { create(:user) }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "自分が所持している記事のレコードを更新しようとするとき" do
       let(:article) { create(:article, user: current_user) }
@@ -76,6 +77,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       # rubocop:disable RSpec/MultipleExpectations
       it "記事を更新できる" do
         # rubocop:enable RSpec/MultipleExpectations
+
         expect { subject }.to change { article.reload.title }.from(article.title).to(params[:article][:title]) &
                               change { article.reload.body }.from(article.body).to(params[:article][:body])
         expect(response).to have_http_status(:ok)
@@ -93,11 +95,11 @@ RSpec.describe "Api::V1::Articles", type: :request do
   end
 
   describe "DELETE /api/v1/articles/:id" do
-    subject { delete(api_v1_article_path(article_id)) }
+    subject { delete(api_v1_article_path(article_id), headers: headers) }
 
     let(:current_user) { create(:user) }
     let(:article_id) { article.id }
-    before { allow_any_instance_of(Api::V1::BaseApiController).to receive(:current_user).and_return(current_user) }
+    let(:headers) { current_user.create_new_auth_token }
 
     context "自分の記事を削除しようとするとき" do
       let!(:article) { create(:article, user: current_user) }
@@ -105,6 +107,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       # rubocop:disable RSpec/MultipleExpectations
       it "記事を削除できる" do
         # rubocop:enable RSpec/MultipleExpectations
+
         expect { subject }.to change { Article.count }.by(-1)
         expect(response).to have_http_status(:ok)
       end


### PR DESCRIPTION
## 概要
 - タイトルの通り

## 補足
 - _Controller_ で定義していた、ダミーの current_userメソッドを削除
 - _Spec_ ファイルで定義していた、スタブを削除
   - その代わりに **テストでログインが必要な API を叩く**際に _headers_ を渡すように実装