### PR TITLE
自分が書いた記事一覧の取得

### DIFF
--- a/app/controllers/api/v1/current/articles_controller.rb
+++ b/app/controllers/api/v1/current/articles_controller.rb
@@ -1,0 +1,10 @@
+module Api::V1
+  class Current::ArticlesController < BaseApiController
+    before_action :authenticate_user!
+
+    def index
+      articles = current_user.articles.published.order(updated_at: :desc)
+      render json: articles, each_serializer: Api::V1::ArticlePreviewSerializer
+    end
+  end
+end

--- a/app/serializers/api/v1/article_preview_serializer.rb
+++ b/app/serializers/api/v1/article_preview_serializer.rb
@@ -1,3 +1,4 @@
 class Api::V1::ArticlePreviewSerializer < ActiveModel::Serializer
   attributes :id, :title, :updated_at
+  belongs_to :user, serializer: Api::V1::UserSerializer
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,9 @@ Rails.application.routes.draw do
       namespace :articles do
         resources :drafts, only: [:index, :show]
       end
+      namespace :current do
+        resources :articles, only: [:index]
+      end
       resources :articles
     end
   end

--- a/spec/requests/api/v1/articles_spec.rb
+++ b/spec/requests/api/v1/articles_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe "Api::V1::Articles", type: :request do
       subject
       res = JSON.parse(response.body)
       expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
-      expect(res[0].keys).to eq ["id", "title", "updated_at"]
+      expect(res[0].keys).to eq ["id", "title", "updated_at", "user"]
     end
   end
 

--- a/spec/requests/api/v1/current/articles_spec.rb
+++ b/spec/requests/api/v1/current/articles_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Current::Articles", type: :request do
+  describe "GET /api/v1/current/articles" do
+    subject { get(api_v1_current_articles_path, headers: headers) }
+
+    let(:headers) { current_user.create_new_auth_token }
+    let(:current_user) { create(:user) }
+
+    context "複数の記事が存在するとき" do
+      let!(:article1) { create(:article, :published, user: current_user, updated_at: 1.day.ago) }
+      let!(:article2) { create(:article, :published, user: current_user, updated_at: 2.days.ago) }
+      let!(:article3) { create(:article, :published, user: current_user) }
+
+      before do
+        create(:article, :draft, user: current_user)
+        create(:article, :published)
+      end
+
+      # rubocop:disable RSpec/MultipleExpectations
+      it "自分の書いた公開記事を更新順に取得できる" do
+        # rubocop:enable RSpec/MultipleExpectations
+
+        subject
+        res = JSON.parse(response.body)
+        expect(response).to have_http_status(:ok)
+        expect(res.length).to eq 3
+        expect(res.map {|d| d["id"] }).to eq [article3.id, article1.id, article2.id]
+        expect(res[0]["user"]["id"]).to eq current_user.id
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要
 - タイトルの通り

## 内容
 - マイページの実装
   - 自分が書いた公開記事の一覧を取得する API とテストを実装

## 補足
 - 下記のように endpoint を設定
   - `/api/v1/current/articles`