### PR TITLE
bundler のバージョンを変更

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,6 +118,8 @@ GEM
     nio4r (2.5.8)
     nokogiri (1.13.3-x86_64-darwin)
       racc (~> 1.4)
+    nokogiri (1.13.3-x86_64-linux)
+      racc (~> 1.4)
     orm_adapter (0.5.0)
     parallel (1.21.0)
     parser (3.1.1.0)
@@ -262,6 +264,7 @@ GEM
 
 PLATFORMS
   x86_64-darwin-20
+  x86_64-linux
 
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
@@ -295,4 +298,4 @@ RUBY VERSION
    ruby 2.7.4p191
 
 BUNDLED WITH
-   2.2.26
+   2.3.10


### PR DESCRIPTION
## 概要
タイトルの通り

## 内容
 - heroku にデプロイする際に起きたエラーを解消
   - Bundler のバージョンを 2.2.26 => 2.3.10 へ変更

## 補足
- `$ bundle lock --add-platform x86_64-linux` を実行